### PR TITLE
Fix testing bug [semver:major]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,6 @@ workflows:
 
       # an example job
       - perl/build:
-          codecov: true
           save-to-workspace: true
           save-to-artifacts: true
       - perl/test-linux:


### PR DESCRIPTION
This pull request is only changes the way we test this orb.  No feature changes in the orb itself.

## What Changed And Why?

Enabling the "codecov: true" parameter asks for the docker image to upload to codecov.io *without* supplying a token, which is possible because codecov has special support for CircleCI (it'll use the CircleCI API to work out what to
do.)

However, when we're building the test-integration jobs then we're not running the job in the "standard" way that codecov expects.  It gets confused, and fails.

In short: This feature works, but can't be tested with the test-integration job.